### PR TITLE
Make Main Factory Method Name Configurable

### DIFF
--- a/config/universal-factory.php
+++ b/config/universal-factory.php
@@ -11,4 +11,18 @@ return [
     |
     */
     'default_namespace' => 'App\\Factories\\',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Universal Factory Method Name
+    |--------------------------------------------------------------------------
+    |
+    | This value allows the user to specify the name of the factory method
+    | provided by the HasUniversalFactory trait.
+
+    | For example, if your source class does too much, and already has a poorly
+    | designed static factory() method that we cannot just override.
+    |
+    */
+    'method_name' => 'factory',
 ];

--- a/src/Traits/HasUniversalFactory.php
+++ b/src/Traits/HasUniversalFactory.php
@@ -10,13 +10,29 @@ use BeneathTheSurfaceLabs\UniversalFactory\UniversalFactory;
 trait HasUniversalFactory
 {
     /**
+     * Dynamically provide the factory method for the model based on config.
+     */
+    public static function __callStatic($method, $arguments)
+    {
+        $factoryMethodName = config('universal-factory.method_name', 'factory');
+
+        // Check if the called method is the factory method
+        if ($method === $factoryMethodName) {
+            return self::getUniversalFactory(...$arguments);
+        }
+
+        // If method doesn't match, continue as normal
+        throw new \BadMethodCallException("Method {$method} does not exist.");
+    }
+
+    /**
      * Get a new factory instance for the model.
      *
      * @param  (callable(array<string, mixed>, static|null): array<string, mixed>)|array<string, mixed>|int|null  $count
      * @param  (callable(array<string, mixed>, static|null): array<string, mixed>)|array<string, mixed>  $state
      * @return TUniversalFactory
      */
-    public static function factory($count = null, $state = [])
+    protected static function getUniversalFactory($count = null, $state = [])
     {
         // Get factory for this class using the base factory logic
         $factory = static::newFactory() ?? UniversalFactory::factoryForClass(get_called_class());

--- a/tests/UniversalFactoryTest.php
+++ b/tests/UniversalFactoryTest.php
@@ -4,6 +4,7 @@ use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileData;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileDataFactory;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfo;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfoFactory;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 
 it('Can Create A New Factory Instance', function () {
@@ -119,3 +120,9 @@ it('It Can Set A Custom Resolver For Guessing Class Names', function (string $cl
     'UserInfo' => [UserInfo::class],
     'ProfileData' => [ProfileData::class],
 ]);
+
+it('It Can Set A Custom Method Name For Universal Factory', function () {
+    Config::set('universal-factory.method_name', 'fake');
+    $factory = UserInfo::fake();
+    expect($factory)->toBeInstanceOf(UserInfoFactory::class);
+});


### PR DESCRIPTION
This PR adds a config key named "method_name" which allows users to specify the name of the factory method provided by the `HasUniversalFactory` trait.

We added a test for this functionality. 