### PR TITLE
Feature: Add Class Construction Strategies

### DIFF
--- a/src/Enum/ClassConstructionStrategy.php
+++ b/src/Enum/ClassConstructionStrategy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BeneathTheSurfaceLabs\UniversalFactory\Enum;
+enum ClassConstructionStrategy
+{
+    case ARRAY_BASED;
+
+    case CONTAINER_BASED;
+}

--- a/src/Enum/ClassConstructionStrategy.php
+++ b/src/Enum/ClassConstructionStrategy.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace BeneathTheSurfaceLabs\UniversalFactory\Enum;
+
 enum ClassConstructionStrategy
 {
     case ARRAY_BASED;

--- a/src/UniversalFactory.php
+++ b/src/UniversalFactory.php
@@ -2,6 +2,7 @@
 
 namespace BeneathTheSurfaceLabs\UniversalFactory;
 
+use BeneathTheSurfaceLabs\UniversalFactory\Enum\ClassConstructionStrategy;
 use Faker\Generator;
 use Faker\Generator as Faker;
 use Illuminate\Container\Container;
@@ -9,7 +10,6 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use BeneathTheSurfaceLabs\UniversalFactory\Enum\ClassConstructionStrategy;
 
 /**
  * @template TClass
@@ -252,9 +252,9 @@ abstract class UniversalFactory
     {
         $class = $this->className();
 
-        return match($this->classConstructionStrategy) {
+        return match ($this->classConstructionStrategy) {
             ClassConstructionStrategy::ARRAY_BASED => new $class($attributes),
-            ClassConstructionStrategy::CONTAINER_BASED =>  app()->makeWith($class, $attributes),
+            ClassConstructionStrategy::CONTAINER_BASED => app()->makeWith($class, $attributes),
         };
     }
 
@@ -363,6 +363,7 @@ abstract class UniversalFactory
     public function useConstructionStrategy(ClassConstructionStrategy $strategy): static
     {
         $this->classConstructionStrategy = $strategy;
+
         return $this;
     }
 

--- a/tests/Examples/ProfileData.php
+++ b/tests/Examples/ProfileData.php
@@ -8,13 +8,22 @@ class ProfileData
 {
     use HasUniversalFactory;
 
-    public function __construct(
-        public ?string $facebookProfileUrl,
-        public ?string $facebookAvatarUrl,
-        public ?string $twitterProfileUrl,
-        public ?string $twitterAvatarUrl,
-        public ?string $gitHubProfileUrl,
-        public ?string $githubAvatarUrl,
-        public ?string $personalUrl,
-    ) {}
+    public ?string $facebookProfileUrl;
+    public ?string $facebookAvatarUrl;
+    public ?string $twitterProfileUrl;
+    public ?string $twitterAvatarUrl;
+    public ?string $gitHubProfileUrl;
+    public ?string $githubAvatarUrl;
+    public ?string $personalUrl;
+
+    public function __construct(array $profileData)
+    {
+        $this->facebookProfileUrl = $profileData['facebookProfileUrl'] ?? null;
+        $this->facebookAvatarUrl = $profileData['facebookAvatarUrl'] ?? null;
+        $this->twitterProfileUrl = $profileData['twitterProfileUrl'] ?? null;
+        $this->twitterAvatarUrl = $profileData['twitterAvatarUrl'] ?? null;
+        $this->gitHubProfileUrl = $profileData['gitHubProfileUrl'] ?? null;
+        $this->githubAvatarUrl = $profileData['githubAvatarUrl'] ?? null;
+        $this->personalUrl = $profileData['personalUrl'] ?? null;
+    }
 }

--- a/tests/Examples/ProfileData.php
+++ b/tests/Examples/ProfileData.php
@@ -9,11 +9,17 @@ class ProfileData
     use HasUniversalFactory;
 
     public ?string $facebookProfileUrl;
+
     public ?string $facebookAvatarUrl;
+
     public ?string $twitterProfileUrl;
+
     public ?string $twitterAvatarUrl;
+
     public ?string $gitHubProfileUrl;
+
     public ?string $githubAvatarUrl;
+
     public ?string $personalUrl;
 
     public function __construct(array $profileData)

--- a/tests/Examples/ProfileDataFactory.php
+++ b/tests/Examples/ProfileDataFactory.php
@@ -2,11 +2,14 @@
 
 namespace BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples;
 
-use BeneathTheSurfaceLabs\UniversalFactory\UniversalFactory;
 use Illuminate\Support\Str;
+use BeneathTheSurfaceLabs\UniversalFactory\UniversalFactory;
+use BeneathTheSurfaceLabs\UniversalFactory\Enum\ClassConstructionStrategy;
 
 class ProfileDataFactory extends UniversalFactory
 {
+    protected ClassConstructionStrategy $classConstructionStrategy = ClassConstructionStrategy::ARRAY_BASED;
+
     /**
      * Define the class's default attributes.
      *

--- a/tests/Examples/ProfileDataFactory.php
+++ b/tests/Examples/ProfileDataFactory.php
@@ -2,9 +2,9 @@
 
 namespace BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples;
 
-use Illuminate\Support\Str;
-use BeneathTheSurfaceLabs\UniversalFactory\UniversalFactory;
 use BeneathTheSurfaceLabs\UniversalFactory\Enum\ClassConstructionStrategy;
+use BeneathTheSurfaceLabs\UniversalFactory\UniversalFactory;
+use Illuminate\Support\Str;
 
 class ProfileDataFactory extends UniversalFactory
 {

--- a/tests/UniversalFactoryTest.php
+++ b/tests/UniversalFactoryTest.php
@@ -1,18 +1,21 @@
 <?php
 
-use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileData;
-use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileDataFactory;
-use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfo;
-use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfoFactory;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Config;
+use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfo;
+use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileData;
+use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfoFactory;
+use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileDataFactory;
 
-it('Can Create A New Factory Instance', function () {
-    $factory = UserInfo::factory();
-    expect($factory)->toBeInstanceOf(UserInfoFactory::class);
-});
+test('Can Create A New Factory Instance', function (string $class, string $expectedFactoryClass) {
+    $factory = $class::factory();
+    expect($factory)->toBeInstanceOf($expectedFactoryClass);
+})->with([
+    'UserInfo' => [UserInfo::class, UserInfoFactory::class],
+    'ProfileData' => [ProfileData::class, ProfileDataFactory::class],
+]);
 
-it('Can Make A New Class With Empty State', function () {
+test('Can Make A New Class With Empty State', function () {
     $factory = UserInfo::factory();
     $result = $factory->make();
     expect($result->age)->toBeBetween(21, 40);
@@ -26,7 +29,7 @@ it('Can Make A New Class With Empty State', function () {
 
 });
 
-it('Can Make Many New Classes With Empty State', function () {
+test('Can Make Many New Classes With Empty State', function () {
     $factory = UserInfo::factory();
     $count = 5;
     $result = $factory->count($count)->make();
@@ -40,7 +43,7 @@ it('Can Make Many New Classes With Empty State', function () {
     });
 });
 
-it('Can Make A New Class With State Overrides via factory()', function () {
+test('Can Make A New Class With State Overrides via factory()', function () {
     $factory = UserInfo::factory(['name' => 'Eric Cartman', 'email' => 'eric@southparkcows.com']);
     $result = $factory->make();
 
@@ -50,7 +53,7 @@ it('Can Make A New Class With State Overrides via factory()', function () {
     expect($result->birthday)->toBeInstanceOf(\DateTime::class);
 });
 
-it('Can Make A New Class With State Overrides via make()', function () {
+test('Can Make A New Class With State Overrides via make()', function () {
     $factory = UserInfo::factory();
     $result = $factory->make(['name' => 'Eric Cartman', 'email' => 'eric@southparkcows.com']);
 
@@ -60,7 +63,7 @@ it('Can Make A New Class With State Overrides via make()', function () {
     expect($result->birthday)->toBeInstanceOf(\DateTime::class);
 });
 
-it('Can Make A Many New Classes With State Overrides via factory()', function () {
+test('Can Make A Many New Classes With State Overrides via factory()', function () {
     $factory = UserInfo::factory(['name' => 'Eric Cartman', 'email' => 'eric@southparkcows.com']);
     $count = 5;
     $result = $factory->count($count)->make();
@@ -73,7 +76,7 @@ it('Can Make A Many New Classes With State Overrides via factory()', function ()
     });
 });
 
-it('Can Make A Many New Classes With State Overrides via make()', function () {
+test('Can Make A Many New Classes With State Overrides via make()', function () {
     $factory = UserInfo::factory();
     $count = 5;
     $result = $factory->count($count)->make(['name' => 'Eric Cartman', 'email' => 'eric@southparkcows.com']);
@@ -86,7 +89,7 @@ it('Can Make A Many New Classes With State Overrides via make()', function () {
     });
 });
 
-it('Can Make A New Class via Factory With State Methods', function () {
+test('Can Make A New Class via Factory With State Methods', function () {
     $factory = UserInfo::factory()->restrictedAge();
     $result = $factory->make();
     expect($result->age)->toBeBetween(0, 12);
@@ -95,7 +98,7 @@ it('Can Make A New Class via Factory With State Methods', function () {
     expect($result->birthday)->toBeBetween(new DateTime('-12 years'), new DateTime);
 });
 
-it('It Can Resolve The Base Classes From The Factories', function (string $factoryClassName, string $expectedClassName) {
+test('Can Resolve The Base Classes From The Factories', function (string $factoryClassName, string $expectedClassName) {
     $className = app($factoryClassName)->className();
     expect($className)->toEqual($expectedClassName);
 })->with([
@@ -103,7 +106,7 @@ it('It Can Resolve The Base Classes From The Factories', function (string $facto
     'ProfileDataFactory' => [ProfileDataFactory::class, ProfileData::class],
 ]);
 
-it('It Can Resolve The Factory Class From The Base Classes', function (string $className, string $expectedFactoryClassName) {
+test('Can Resolve The Factory Class From The Base Classes', function (string $className, string $expectedFactoryClassName) {
     $factory = $className::factory()::resolveFactoryName($className);
     expect($factory)->toEqual($expectedFactoryClassName);
 })->with([
@@ -111,7 +114,7 @@ it('It Can Resolve The Factory Class From The Base Classes', function (string $c
     'ProfileData' => [ProfileData::class, ProfileDataFactory::class],
 ]);
 
-it('It Can Set A Custom Resolver For Guessing Class Names', function (string $className) {
+test('Can Set A Custom Resolver For Guessing Class Names', function (string $className) {
     $factory = $className::factory();
     $factory->guessClassNamesUsing(fn ($factory) => $className);
     expect($factory->className())->toEqual($className);
@@ -121,8 +124,9 @@ it('It Can Set A Custom Resolver For Guessing Class Names', function (string $cl
     'ProfileData' => [ProfileData::class],
 ]);
 
-it('It Can Set A Custom Method Name For Universal Factory', function () {
+test('Can Set A Custom Method Name For Universal Factory', function () {
     Config::set('universal-factory.method_name', 'fake');
     $factory = UserInfo::fake();
     expect($factory)->toBeInstanceOf(UserInfoFactory::class);
 });
+

--- a/tests/UniversalFactoryTest.php
+++ b/tests/UniversalFactoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Config;
-use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfo;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileData;
-use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfoFactory;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileDataFactory;
+use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfo;
+use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfoFactory;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
 
 test('Can Create A New Factory Instance', function (string $class, string $expectedFactoryClass) {
     $factory = $class::factory();
@@ -129,4 +129,3 @@ test('Can Set A Custom Method Name For Universal Factory', function () {
     $factory = UserInfo::fake();
     expect($factory)->toBeInstanceOf(UserInfoFactory::class);
 });
-


### PR DESCRIPTION
This pull request adds the ability for developers to customize the way their factory constructs the host class. 

The default, Container Based Construction, takes advantage of Laravel's Container to resolve and construct your class. 

The second strategy, Array Based Construction, assumes your class constructor takes an array as input, mapping the keys to class properties. This is similar to how Eloquent models or Laravel Data classes work. 

Of course, by overriding the `newClass()` method within your factory, developers can implement their own strategy.

See the ReadMe for examples. 