### PR TITLE
Feature: Add new "reflection based" construction strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ This package supports a few common strategies to instruct your factory how to co
 
 By default, this package will use the `ClassConstructionStrategy::CONTAINER_BASED` strategy, which takes advantage of the Laravel container to attempt to construct your class.  
 
-The other strategy assumes your class constructor takes an array of parameters, which will map to your class properties. This is similar to how Eloquent models or Laravel Data classes are constructed.
+Another, `ClassConstructionStrategy::REFLECTION_BASED`, uses PHP's Reflection classes to examine your class, and directly set the parameters it is able to inspect. 
+
+The last strategy, `ClassConstructionStrategy::ARRAY_BASED`, assumes your class constructor takes an array of parameters, which will map to your class properties. This is similar to how Eloquent models are constructed.
 
 Of course, if your class requires something more custom or complex to be constructed, you can easily override the newClass() method within your factory class.
 

--- a/src/Enum/ClassConstructionStrategy.php
+++ b/src/Enum/ClassConstructionStrategy.php
@@ -7,4 +7,6 @@ enum ClassConstructionStrategy
     case ARRAY_BASED;
 
     case CONTAINER_BASED;
+
+    case REFLECTION_BASED;
 }

--- a/tests/Examples/UserInfoFactory.php
+++ b/tests/Examples/UserInfoFactory.php
@@ -16,7 +16,7 @@ class UserInfoFactory extends UniversalFactory
     public function definition(): array
     {
         return [
-            'externalId' => fn () => substr(str_replace(['+', '.', 'E'], '', microtime(true)), -10),
+            'externalId' => fn () => substr(str_replace(['+', '.', 'E'], '', microtime(false)), -10),
             'name' => $this->faker->name,
             'email' => $this->faker->email,
             'birthday' => $this->faker->dateTime,

--- a/tests/UniversalFactoryTest.php
+++ b/tests/UniversalFactoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use BeneathTheSurfaceLabs\UniversalFactory\Enum\ClassConstructionStrategy;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileData;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\ProfileDataFactory;
 use BeneathTheSurfaceLabs\UniversalFactory\Tests\Examples\UserInfo;
@@ -128,4 +129,18 @@ test('Can Set A Custom Method Name For Universal Factory', function () {
     Config::set('universal-factory.method_name', 'fake');
     $factory = UserInfo::fake();
     expect($factory)->toBeInstanceOf(UserInfoFactory::class);
+});
+
+test('Can Use Reflection To Construct Class', function () {
+    $factory = UserInfo::factory()->useConstructionStrategy(ClassConstructionStrategy::REFLECTION_BASED);
+    $result = $factory->make();
+    expect($result)->toBeInstanceOf(UserInfo::class);
+    expect($result->age)->toBeBetween(21, 40);
+    expect($result->name)->toBeString();
+    expect(Str::of($result->email)->contains('@'))->toBeTrue();
+    expect($result->birthday)->toBeInstanceOf(\DateTime::class);
+    expect($result->profileData)->toBeInstanceOf(ProfileData::class);
+    expect($result->profileData->facebookProfileUrl)->toContain('https://facebook.com/');
+    expect($result->profileData->twitterProfileUrl)->toContain('https://x.com/');
+    expect($result->profileData->gitHubProfileUrl)->toContain('https://github.com/');
 });


### PR DESCRIPTION
This pull request adds an additional strategy for constructing classes within the UniversalFactory class - Reflection Based Construction.

The existing strategies were: 

- Container Based Construction: takes advantage of Laravel's Container to resolve and construct your class.

- Array Based Construction: assumes your class constructor takes an array as input, mapping the keys to class properties. This is similar to how Eloquent models or Laravel Data classes work.

The new strategy: 

- Reflection Based Construction: uses PHP's Reflection features to examine your class and directly set the parameters it can inspect.

Same as always, by overriding the newClass() method within your factory, developers can implement their own strategy.

See the ReadMe for examples.