### PR TITLE
Bugfix: Do not treat enums as callable under any circumstances

### DIFF
--- a/src/UniversalFactory.php
+++ b/src/UniversalFactory.php
@@ -220,7 +220,7 @@ abstract class UniversalFactory
                 if (
                     is_callable($attribute) &&
                     ! is_string($attribute) &&
-                    ! is_array($attribute)  &&
+                    ! is_array($attribute) &&
                     ! enum_exists(is_object($attribute) ? get_class($attribute) : '')
                 ) {
                     $attribute = $attribute($definition);

--- a/src/UniversalFactory.php
+++ b/src/UniversalFactory.php
@@ -216,7 +216,13 @@ abstract class UniversalFactory
                 if ($attribute instanceof UniversalFactory) {
                     $attribute = $attribute->make();
                 }
-                if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
+
+                if (
+                    is_callable($attribute) &&
+                    ! is_string($attribute) &&
+                    ! is_array($attribute)  &&
+                    ! enum_exists(is_object($attribute) ? get_class($attribute) : '')
+                ) {
                     $attribute = $attribute($definition);
                 }
 


### PR DESCRIPTION
A bit of an edge case perhaps, but this PR fixes some strange side effects seen when your factory contains a property which is enums that have an __invoke() method, which causes is_callable() to return true.

This happens to be the case for a few popular enum packages out there.

We correct this by checking if the factory attribute is an enum, and making sure we do not treat it as a callable.

These changes may need to go further -- and avoid using is_callable() altogether, while making sure to still check for methods/functions with more explicit checks and additional logic. 