### PR TITLE
Add Laravel 12.x Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0"
+        "illuminate/contracts": "^10.0||^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
Updated composer.json to allow installation with illuminate/contracts version 12.x, providing compatibility with the latest versions of Laravel.